### PR TITLE
Update to HA 2023.5.3

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,2 +1,2 @@
 env:
-  version: 2023.4.6
+  version: 2023.5.3


### PR DESCRIPTION
Current version of HA is `2023.5.3` - would be awesome to update this docker image and the helm charts :) 